### PR TITLE
Allow map data types to export and import via base64 json representation

### DIFF
--- a/vault/client.go
+++ b/vault/client.go
@@ -160,11 +160,3 @@ func (v *Vault) Write(path string, data map[string]interface{}, ver string) erro
 
 	return err
 }
-
-func createKeyValuePairs(m map[string]interface{}) string {
-	b := new(bytes.Buffer)
-	for key, value := range m {
-		fmt.Fprintf(b, "%s:\"%s\"\n", key, value)
-	}
-	return b.String()
-}


### PR DESCRIPTION
I've impoved you fix to allow json values to be serialized as base64 json. During import operation I check if value is a valid json and if yes I write it as a map. 